### PR TITLE
Improve flake.nix, conforming to the output schema

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707597397,
-        "narHash": "sha256-LwJ5aO9EtgkSlYdR35c2oQfUu/+0HycOBJCiLE6Ckss=",
+        "lastModified": 1707657644,
+        "narHash": "sha256-DD6Qg0KQiKWpW9Hvk1JebgSue5v9Ds+fUyVlhnsN5e0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c00ace12ae50ead6c5ae4e21146336277827910b",
+        "rev": "0dc186716d75fcea44ec5ae33d6a9540015072a3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,35 +1,53 @@
 {
-  description = "REST API for any Postgres database";
+  description = "A Pacman inspired frontend for Nix";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
   outputs = { self, nixpkgs }:
-    with import nixpkgs { system = "x86_64-linux"; };
+    let
+      lib = nixpkgs.lib;
+      allSystems = lib.systems.flakeExposed;
+      forAllSystems = lib.genAttrs allSystems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pinix =
+            { rustPlatform
+            , installShellFiles
+            , lib
+            }:
+            rustPlatform.buildRustPackage {
+              pname = "pinix";
+              version = "0.1.0";
+              src = ./.;
+              nativeBuildInputs = [ installShellFiles ];
 
-    pkgs.rustPlatform.buildRustPackage rec {
-      pname = "pinix";
-      version = "0.1.0";
-      src = ./.;
-      nativeBuildInputs = [ pkgs.installShellFiles ];
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+                outputHashes = {
+                  "console-0.16.0" = "sha256-t5hydPT3BXJqPl8zKieaId3KUltEbRPh2xmZMhy8Ut0=";
+                  "indicatif-0.17.8" = "sha256-8xrGqDb6iUDhdvY937XFqC3GIZpq4tPMZAkKm218c/0=";
+                };
+              };
 
+              meta = with lib; {
+                description = "A Pacman inspired frontend for Nix";
+                homepage = "https://github.com/remi-dupre/pinix";
+                license = licenses.lgpl3;
+                mainProgram = "pinix";
+              };
 
-      cargoLock = {
-        lockFile = ./Cargo.lock;
-        outputHashes = {
-          "console-0.16.0" = "sha256-t5hydPT3BXJqPl8zKieaId3KUltEbRPh2xmZMhy8Ut0=";
-          "indicatif-0.17.8" = "sha256-8xrGqDb6iUDhdvY937XFqC3GIZpq4tPMZAkKm218c/0=";
-        };
-      };
-
-      meta = with pkgs.lib; {
-        description = "A Pacman inspired frontend for Nix";
-        homepage = "https://github.com/remi-dupre/pinix";
-        license = licenses.lgpl3;
-        mainProgram = "pinix";
-      };
-
-      cargoSha256 = "sha256-6hKbAL3a1t1mHNUvvi65e/BkFoJQmvpZQlU58csmol4=";
+              cargoSha256 = "sha256-6hKbAL3a1t1mHNUvvi65e/BkFoJQmvpZQlU58csmol4=";
+            };
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          pinix = pkgs.callPackage pinix { };
+          default = self.packages.${system}.pinix;
+        }
+      );
     };
 }


### PR DESCRIPTION
Thank you for this wonderful program! This adds a few minor improvements for the `flake.nix` which makes it work better for myself.

- Point nixpkgs to the "unstable" channel which enjoys binary caches, and bump flake.lock
- Do not import nixpkgs; instead, use `legacyPackages.${system}` for better performance and composability.
- Abstract pinix into a "package" and invoke with `pkgs.callPackage`, for future convenience.
- Rewrite flake outputs such that it works well with the `nix build` and `nix develop` commands.

See: https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix#installables